### PR TITLE
Add finalfusion tensorflow ops.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,9 @@ project(finalfusion_cxx)
 
 enable_testing()
 
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
 add_subdirectory(finalfusion-ffi)
+add_subdirectory(finalfusion-tf)
 add_subdirectory(src)
 add_subdirectory(tests)

--- a/finalfusion-tf/CMakeLists.txt
+++ b/finalfusion-tf/CMakeLists.txt
@@ -1,0 +1,17 @@
+execute_process(COMMAND python -c "import tensorflow as tf; print(tf.sysconfig.get_lib(), end=\"\")" OUTPUT_VARIABLE LIBTENSORFLOW_FRAMEWORK ERROR_QUIET)
+execute_process(COMMAND python -c "import tensorflow as tf; print(\" \".join(tf.sysconfig.get_compile_flags()), end=\"\")" OUTPUT_VARIABLE TF_CFLAGS ERROR_QUIET)
+set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} ${TF_CFLAGS} -DNDEBUG")
+
+set(LIBTENSORFLOW_FRAMEWORK "${LIBTENSORFLOW_FRAMEWORK}/libtensorflow_framework.so.1")
+
+add_library(libtensorflow_framework SHARED IMPORTED GLOBAL)
+set_target_properties(libtensorflow_framework PROPERTIES
+        IMPORTED_LOCATION ${LIBTENSORFLOW_FRAMEWORK})
+
+add_library(finalfusion_tf lookup/ff_lookup.cc)
+target_include_directories(finalfusion_tf PUBLIC ${PROJECT_SOURCE_DIR}/include)
+target_link_libraries(finalfusion_tf finalfusion_cxx)
+
+add_library(finalfusion_tf_op SHARED kernel/ff_lookup_kernels.cc ops/ff_lookup_ops.cc)
+target_include_directories(finalfusion_tf_op PUBLIC ${PROJECT_SOURCE_DIR}/include)
+target_link_libraries(finalfusion_tf_op finalfusion_tf libtensorflow_framework)

--- a/finalfusion-tf/kernel/ff_lookup_kernels.cc
+++ b/finalfusion-tf/kernel/ff_lookup_kernels.cc
@@ -1,0 +1,102 @@
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/framework/op.h"
+#include "tensorflow/core/framework/types.h"
+#include "tensorflow/core/framework/resource_handle.h"
+
+#include "finalfusion-cxx/Embeddings.hh"
+#include "finalfusion-tf/ff_lookup.hh"
+
+REGISTER_KERNEL_BUILDER(
+    Name("FFEmbeddings").Device(DEVICE_CPU),
+    ResourceHandleOp<FFLookup>);
+
+class InitializeFFEmbeddingsOp : public OpKernel {
+public:
+  explicit InitializeFFEmbeddingsOp(OpKernelConstruction *context)
+      : OpKernel(context) {}
+
+  void Compute(OpKernelContext *context) override {
+    FFLookup *s;
+    // verbosely fail if the lookup has been initialized before
+    bool found = LookupResource(context, HandleFromInput(context, 0), &s).ok();
+    if (found) {
+      core::ScopedUnref unref(s);
+      context->CtxFailure(errors::AlreadyExists("Lookup has already been created."));
+    }
+
+    const Tensor *tmp;
+    OP_REQUIRES_OK(context, context->input("filename", &tmp));
+    const string path = tmp->scalar<string>()();
+    OP_REQUIRES_OK(context, context->input("mmap", &tmp));
+    const bool mmap = tmp->scalar<bool>()();
+
+    OP_REQUIRES_OK(context, LookupOrCreateResource<FFLookup>(
+        context, HandleFromInput(context, 0), &s,
+        [path, mmap, context](FFLookup **s) {
+          return CreateFFLookup(path, mmap, context->env(), s);
+        }));
+    core::ScopedUnref unref(s);
+  }
+};
+
+REGISTER_KERNEL_BUILDER(
+    Name("InitializeFFEmbeddings").Device(DEVICE_CPU),
+    InitializeFFEmbeddingsOp);
+
+class CloseFFEmbeddingsOp : public OpKernel {
+public:
+  explicit CloseFFEmbeddingsOp(OpKernelConstruction *context)
+      : OpKernel(context) {}
+
+  void Compute(OpKernelContext *context) override {
+    OP_REQUIRES_OK(context, context->resource_manager()->Delete(HandleFromInput(context, 0)));
+  }
+};
+
+REGISTER_KERNEL_BUILDER(
+    Name("CloseFFEmbeddings").Device(DEVICE_CPU), CloseFFEmbeddingsOp);
+
+class FFLookupOp : public OpKernel {
+public:
+  explicit FFLookupOp(OpKernelConstruction *context) : OpKernel(context) {
+    OP_REQUIRES_OK(context, context->GetAttr("mask_empty_string", &mask_empty_string_));
+    OP_REQUIRES_OK(context, context->GetAttr("mask_failed_lookup", &mask_failed_lookup_));
+  }
+
+  void Compute(OpKernelContext *context) override {
+    FFLookup *e;
+    OP_REQUIRES_OK(context, LookupResource(context, HandleFromInput(context, 0), &e));
+    core::ScopedUnref unref(e);
+    OP_REQUIRES(context, e->initialized(), errors::FailedPrecondition("Class was not properly initialized."));
+    size_t embedding_dims = e->dimensions();
+    // Grab the input tensor
+    const Tensor &input_tensor = context->input(1);
+    TensorShape out_shape(input_tensor.shape());
+    out_shape.AddDim(((int64) embedding_dims));
+    auto input = input_tensor.flat<string>();
+    // Create an output tensor
+    Tensor *output_tensor = nullptr;
+    OP_REQUIRES_OK(context, context->allocate_output(0, out_shape,
+                                                     &output_tensor));
+    auto output_flat = output_tensor->flat<float>();
+
+    auto n = input.size();
+    for (int i = 0; i < n; i++) {
+      std::vector<float> embed;
+      Status s = e->embedding(input(i), &embed);
+      if ((input(i).empty() && mask_empty_string_) || (mask_failed_lookup_ && !s.ok())) {
+        std::memset(&output_flat(i * embedding_dims), 0, embedding_dims * 4);
+      } else {
+        OP_REQUIRES(context, s.ok(), s);
+        std::memcpy(&output_flat(i * embedding_dims), embed.data(), embedding_dims * sizeof(float));
+      }
+    }
+  }
+private:
+  bool mask_empty_string_;
+  bool mask_failed_lookup_;
+};
+
+REGISTER_KERNEL_BUILDER(
+    Name("FFLookup").Device(DEVICE_CPU),
+    FFLookupOp);

--- a/finalfusion-tf/lookup/ff_lookup.cc
+++ b/finalfusion-tf/lookup/ff_lookup.cc
@@ -1,0 +1,66 @@
+#include "tensorflow/core/platform/env.h"
+#include "tensorflow/core/lib/core/status.h"
+#include "tensorflow/core/framework/resource_mgr.h"
+
+#include "finalfusion-tf/ff_lookup.hh"
+
+using namespace tensorflow;
+
+FFLookup::FFLookup(Env *env)
+    : ResourceBase(),
+      is_initialized_(false),
+      env_(env) {}
+
+Status FFLookup::Initialize(string const &path, bool mmap) {
+  try {
+    embeddings_ = std::make_unique<Embeddings>(path, mmap);
+  } catch (std::exception &e) {
+    return errors::Unknown(e.what());
+  }
+
+  is_initialized_ = true;
+  return Status::OK();
+}
+
+Status FFLookup::Close() {
+  if (!is_initialized_) {
+    return errors::FailedPrecondition("Can't close uninitialized lookup.");
+  }
+  embeddings_.reset(NULL);
+  return Status::OK();
+}
+
+Status FFLookup::embedding(const string &word, std::vector<float> *result) {
+  *result = embeddings_->embedding(word);
+  if (result->empty()) {
+    return errors::InvalidArgument("Could not retrieve an embedding for: ", word);
+  }
+  return Status::OK();
+}
+
+size_t FFLookup::dimensions() {
+  CHECK_NOTNULL(embeddings_);
+  return embeddings_->dimensions();
+}
+
+bool FFLookup::initialized() {
+  return is_initialized_;
+}
+
+string FFLookup::DebugString() const {
+  return "FFLookup";
+}
+
+/// Creates a new initialized FiFuLookup.
+Status CreateFFLookup(const string &path, const bool mmap, Env *env, FFLookup **result) {
+  FFLookup *ff_lookup = new FFLookup(env);
+  const Status init = ff_lookup->Initialize(path, mmap);
+  if (!init.ok()) {
+    ff_lookup->Unref();
+    *result = nullptr;
+    return init;
+  }
+  *result = ff_lookup;
+
+  return Status::OK();
+}

--- a/finalfusion-tf/ops/ff_lookup_ops.cc
+++ b/finalfusion-tf/ops/ff_lookup_ops.cc
@@ -1,0 +1,44 @@
+#include "tensorflow/core/framework/common_shape_fns.h"
+#include "tensorflow/core/framework/op.h"
+#include "tensorflow/core/framework/shape_inference.h"
+
+using ::tensorflow::shape_inference::ShapeHandle;
+
+namespace tensorflow {
+
+  REGISTER_OP("FFEmbeddings")
+    .Output("lookup: resource")
+    .Attr("shared_name: string = ''")
+    .Attr("container: string = ''")
+    .SetShapeFn(shape_inference::NoOutputs);
+
+  REGISTER_OP("InitializeFFEmbeddings")
+    .Input("embeds: resource")
+    .Input("filename: string")
+    .Input("mmap: bool")
+    .SetShapeFn(shape_inference::NoOutputs);
+
+
+  REGISTER_OP("CloseFFEmbeddings")
+    .Input("embeds: resource")
+    .SetShapeFn(shape_inference::NoOutputs);
+
+  REGISTER_OP("FFLookup")
+    .Input("embeds: resource")
+    .Input("query: string")
+    .Attr("embedding_len: int >= -1 = -1")
+    .Attr("mask_empty_string: bool = true")
+    .Attr("mask_failed_lookup: bool = true")
+    .Output("embeddings: float")
+    .SetShapeFn([](
+      ::tensorflow::shape_inference::InferenceContext *c
+    ) {
+      ShapeHandle strings_shape = c->input(1);
+      ShapeHandle output_shape;
+      int embedding_len;
+      TF_RETURN_IF_ERROR(c->GetAttr("embedding_len", &embedding_len));
+      TF_RETURN_IF_ERROR(
+          c->Concatenate(strings_shape,c->Vector(embedding_len), &output_shape)
+      );
+  });
+}

--- a/include/finalfusion-tf/ff_lookup.hh
+++ b/include/finalfusion-tf/ff_lookup.hh
@@ -1,0 +1,27 @@
+#ifndef FF_LOOKUP_H
+#define FF_LOOKUP_H
+#include "tensorflow/core/lib/core/status.h"
+#include "tensorflow/core/platform/env.h"
+#include "tensorflow/core/framework/resource_mgr.h"
+
+#include "finalfusion-cxx/Embeddings.hh"
+
+using namespace tensorflow;
+
+class FFLookup : public ResourceBase {
+public:
+  FFLookup(Env *env);
+  Status Initialize(string const &filename, bool mmap);
+  Status Close();
+  Status embedding(const string &word, std::vector<float> *result);
+  size_t dimensions();
+  bool initialized();
+  string DebugString() const override;
+private:
+  bool is_initialized_;
+  std::unique_ptr<Embeddings> embeddings_;
+  Env *env_;
+};
+
+Status CreateFFLookup(string const &path, bool mmap, Env *env, FFLookup **result);
+#endif //FF_LOOKUP_H


### PR DESCRIPTION
This PR is not meant to be merged, rather to discuss how we want to structure the tensorflow ops. 

If we create yet another `finalfusion-tf` repo, concerns are nicely separated but we'd have to include a submodule for `finalfusion-cxx` which means having 2 nested submodules, which isn't all that nice imo.

Content wise, I tried to follow how other resources are implemented in tensorflow (e.g. SummaryFileWriter).

Note: CI-builds are expected to be failing since I didn't update the config for python and tensorflow which is required to pull in the headers for tensorflow and `libtensorflow_framework.so.1`. 
I was able to build and load the library both on my machine and on hopper (on 1.14.1).

Maybe @twuebi can also take a look since he was involved with this earlier.